### PR TITLE
(bug fix) move get payload of tabspace inside transaction

### DIFF
--- a/src/data/tabSpace/store.ts
+++ b/src/data/tabSpace/store.ts
@@ -1,15 +1,5 @@
-import { createApi, createStore, forward } from 'effector';
-import { merge } from 'lodash';
-import { exposeDebugData } from '../../debug';
-import { createGeneralStorageStoreAndApi } from '../../storage/GeneralStorage';
-import { storageOverviewApi } from '../../storage/StorageOverview';
-import { Tab } from './Tab';
 import {
-  newEmptyTabPreviewCache,
-  removePreview,
-  setPreview,
-} from './TabPreviewCache';
-import {
+  TabSpace,
   addTabs,
   insertTab,
   newEmptyTabSpace,
@@ -18,11 +8,22 @@ import {
   replaceTab,
   reset,
   setName,
-  TabSpace,
   updateTab,
   updateTabSpace,
 } from './TabSpace';
+import { createApi, createStore, forward } from 'effector';
+import {
+  newEmptyTabPreviewCache,
+  removePreview,
+  setPreview,
+} from './TabPreviewCache';
+
+import { Tab } from './Tab';
+import { createGeneralStorageStoreAndApi } from '../../storage/GeneralStorage';
+import { exposeDebugData } from '../../debug';
+import { merge } from 'lodash';
 import { querySavedTabSpaceCount } from './util';
+import { storageOverviewApi } from '../../storage/StorageOverview';
 
 export const $tabSpace = createStore(newEmptyTabSpace());
 export type TabSpaceStore = typeof $tabSpace;


### PR DESCRIPTION
so that whenever we want to save the tabspace we will always have the updated data, as in sometime deferred save will keep old data passed from parameter. This will finally solve the problem of saving and updating old copy of tabspace problem.